### PR TITLE
Split neighbour_location_on_axis into a wrapping and non-wrapping version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insides"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license-file = "LICENSE.md"
 description = "A compact, high performance space filling curve library for Rust."
@@ -14,7 +14,7 @@ keywords = ["morton", "hilbert", "curve", "quadtree", "octree"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dilate = "0.6.1"
+dilate = "0.6.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0" # For test data

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ First, link insides into your project's cargo.toml.
 Check for the latest version at [crates.io](https://crates.io/crates/insides):
 ```toml
 [dependencies]
-insides = "0.1.1"
+insides = "0.1.2"
 ```
 
 Next, import insides into your project and try out some of the features:


### PR DESCRIPTION
The previous implementation of neighbour_location_on_axis was wrapping by default between 0-COORD_MAX, which is not always desirable.

neighbour_location_on_axis is now the non-wrapping version and returns an Option::None if the coordinate would have wrapped.

neighbour_location_on_axis_wrapping is the original wrapping behaviour.