### PR TITLE
Add neighbour_on_corner methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 version: 2.1
 
-orbs: 
-  rust: circleci/rust@1.6.0
-
-workflows:
-  production:
-    jobs:
-      - rust/lint-test-build:
-          release: true
-          version: 1.58.0
+jobs:
+  build:
+    docker:
+      - image: cimg/rust:1.63.0
+    steps:
+      - checkout
+      - run: cargo --version
+      - run:
+          name: Run Tests
+          command: "cargo test"

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -146,6 +146,7 @@ pub(crate) mod tests {
     use std::{collections::HashSet, fmt::Debug, marker::PhantomData, panic::catch_unwind};
 
     const MAX_TESTED_INDICES: usize = 100000;
+    const MAX_PERMUTATIONS: usize = 10000;
 
     pub struct SpaceFillingCurveTester<SFC, const D: usize>(PhantomData<SFC>)
     where
@@ -384,6 +385,81 @@ pub(crate) mod tests {
                 }
             }
         }
+        
+        pub fn neighbour_on_corner_is_correct()
+        where
+            SFC: Neighbours<D>,
+            <SFC as SpaceFillingCurve<D>>::Coord: Debug,
+        {
+            let num_indices: usize = SFC::INDEX_MAX.to_usize().min(MAX_TESTED_INDICES / D);
+            for i in 0..num_indices {
+                // It's a shame that we have to rely on other SFC methods to test this trait... not sure of a better solution yet
+                let sfc = SFC::from_index(NumTraits::from_usize(i));
+                let coords = sfc.coords();
+
+                let num_corners = (1usize << D).min(MAX_PERMUTATIONS);
+                for corner in 0..num_corners {
+                    let test_axes = core::array::from_fn(|i| if (corner >> i) & 0x1 != 0 { QueryDirection::Positive } else { QueryDirection::Negative });
+
+                    let mut expected_coords = coords;
+                    let mut valid = true;
+                    for axis in 0..D {
+                        if matches!(test_axes[axis], QueryDirection::Positive) {
+                            if coords[axis] < SFC::COORD_MAX {
+                                expected_coords[axis] = coords[axis].add(NumTraits::one());
+                            } else {
+                                valid = false;
+                            }
+                        } else {
+                            if coords[axis] > NumTraits::zero() {
+                                expected_coords[axis] = coords[axis].sub(NumTraits::one());
+                            } else {
+                                valid = false;
+                            }
+                        }
+                    }
+                    let expected = valid.then(|| SFC::from_coords(expected_coords));
+                    assert_eq!(sfc.neighbour_on_corner(test_axes), expected);
+                }
+            }
+        }
+        
+        pub fn neighbour_on_corner_wrapping_is_correct()
+        where
+            SFC: Neighbours<D>,
+            <SFC as SpaceFillingCurve<D>>::Coord: Debug,
+        {
+            let num_indices: usize = SFC::INDEX_MAX.to_usize().min(MAX_TESTED_INDICES / D);
+            for i in 0..num_indices {
+                // It's a shame that we have to rely on other SFC methods to test this trait... not sure of a better solution yet
+                let sfc = SFC::from_index(NumTraits::from_usize(i));
+                let coords = sfc.coords();
+
+                let num_corners = (1usize << D).min(MAX_PERMUTATIONS);
+                for corner in 0..num_corners {
+                    let test_axes = core::array::from_fn(|i| if (corner >> i) & 0x1 != 0 { QueryDirection::Positive } else { QueryDirection::Negative });
+
+                    let mut expected_coords = coords;
+                    for axis in 0..D {
+                        if matches!(test_axes[axis], QueryDirection::Positive) {
+                            if coords[axis] < SFC::COORD_MAX {
+                                expected_coords[axis] = coords[axis].add(NumTraits::one());
+                            } else {
+                                expected_coords[axis] = NumTraits::zero();
+                            }
+                        } else {
+                            if coords[axis] > NumTraits::zero() {
+                                expected_coords[axis] = coords[axis].sub(NumTraits::one());
+                            } else {
+                                expected_coords[axis] = SFC::COORD_MAX;
+                            }
+                        }
+                    }
+                    let expected = SFC::from_coords(expected_coords);
+                    assert_eq!(sfc.neighbour_on_corner_wrapping(test_axes), expected);
+                }
+            }
+        }
     }
 
     macro_rules! test_curve {
@@ -472,6 +548,16 @@ pub(crate) mod tests {
                     #[test]
                     fn neighbour_on_axis_wrapping_is_correct() {
                         SpaceFillingCurveTester::<TestedCurve, $d>::neighbour_on_axis_wrapping_is_correct();
+                    }
+
+                    #[test]
+                    fn neighbour_on_corner_is_correct() {
+                        SpaceFillingCurveTester::<TestedCurve, $d>::neighbour_on_corner_is_correct();
+                    }
+
+                    #[test]
+                    fn neighbour_on_corner_wrapping_is_correct() {
+                        SpaceFillingCurveTester::<TestedCurve, $d>::neighbour_on_corner_wrapping_is_correct();
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@ pub trait Siblings<const D: usize>: SpaceFillingCurve<D> {
 pub trait Neighbours<const D: usize>: SpaceFillingCurve<D> {
     /// Get neighbour location on axis
     ///
-    /// This method gets the neighbour location in a direction along on an axis.
+    /// This method gets the neighbour location in a direction along an axis.
     /// It is equvalent to adding 1 to or subtracting 1 from the encoded
     /// coordinate.
     ///
@@ -393,7 +393,7 @@ pub trait Neighbours<const D: usize>: SpaceFillingCurve<D> {
 
     /// Get neighbour location on axis with wrapping
     ///
-    /// This method gets the neighbour location in a direction along on an axis.
+    /// This method gets the neighbour location in a direction along an axis.
     /// It is equvalent to adding 1 to or subtracting 1 from the encoded
     /// coordinate.
     ///
@@ -428,6 +428,74 @@ pub trait Neighbours<const D: usize>: SpaceFillingCurve<D> {
     /// ```
     fn neighbour_on_axis_wrapping(&self, axis: usize, direction: QueryDirection) -> Self;
 
+    /// Get neighbour location on corner
+    ///
+    /// This method gets the neighbour location in a direction along each axis. This results finding the
+    /// adjecant diagonal locations (the corners). It is equvalent to adding 1 to or subtracting 1 from
+    /// each axis of the coordinates.
+    ///
+    /// If the neighbour would cause a coordinate to wrap, this method returns
+    /// None instead. For a wrapping version, please see
+    /// [neighbour_on_corner_wrapping()](Neighbours::neighbour_on_corner_wrapping()).
+    ///
+    /// Unlike the [Siblings] implementation, methods in the Neighbours trait
+    /// may cross cluster boundaries.
+    ///
+    /// # Panics
+    /// Panics if parameter 'axis' is greater than or equal to D
+    ///
+    /// # Examples
+    /// ```rust
+    /// use insides::{*, QueryDirection::*};
+    ///
+    /// let location = Morton::<Expand<u16, 3>, 3>::from_coords([1, 2, 3]);
+    ///
+    /// assert_eq!(location.neighbour_on_corner([Negative, Negative, Negative]).unwrap().coords(), [0, 1, 2]);
+    /// assert_eq!(location.neighbour_on_corner([Positive, Positive, Positive]).unwrap().coords(), [2, 3, 4]);
+    /// 
+    /// assert_eq!(location.neighbour_on_corner([Positive, Negative, Negative]).unwrap().coords(), [2, 1, 2]);
+    /// assert_eq!(location.neighbour_on_corner([Negative, Positive, Negative]).unwrap().coords(), [0, 3, 2]);
+    /// assert_eq!(location.neighbour_on_corner([Negative, Negative, Positive]).unwrap().coords(), [0, 1, 4]);
+    ///
+    /// let edge_location = Morton::<Expand<u16, 2>, 2>::from_coords([0, u16::MAX]);
+    /// assert_eq!(edge_location.neighbour_on_corner([Negative, Negative]), None);
+    /// assert_eq!(edge_location.neighbour_on_corner([Positive, Positive]), None);
+    /// ```
     fn neighbour_on_corner(&self, axes: [QueryDirection; D]) -> Option<Self>;
+
+    /// Get neighbour location on corner with wrapping
+    ///
+    /// This method gets the neighbour location in a direction along each axis. This results finding the
+    /// adjecant diagonal locations (the corners). It is equvalent to adding 1 to or subtracting 1 from
+    /// each axis of the coordinates.
+    ///
+    /// This method allows coordinates to wrap between zero and
+    /// [COORD_MAX](SpaceFillingCurve::COORD_MAX). For a non-wrapping version,
+    /// please see
+    /// [neighbour_on_corner()](Neighbours::neighbour_on_corner()).
+    ///
+    /// Unlike the [Siblings] implementation, methods in the Neighbours trait
+    /// may cross cluster boundaries.
+    ///
+    /// # Panics
+    /// Panics if parameter 'axis' is greater than or equal to D
+    ///
+    /// # Examples
+    /// ```rust
+    /// use insides::{*, QueryDirection::*};
+    ///
+    /// let location = Morton::<Expand<u16, 3>, 3>::from_coords([1, 2, 3]);
+    ///
+    /// assert_eq!(location.neighbour_on_corner_wrapping([Negative, Negative, Negative]).coords(), [0, 1, 2]);
+    /// assert_eq!(location.neighbour_on_corner_wrapping([Positive, Positive, Positive]).coords(), [2, 3, 4]);
+    /// 
+    /// assert_eq!(location.neighbour_on_corner_wrapping([Positive, Negative, Negative]).coords(), [2, 1, 2]);
+    /// assert_eq!(location.neighbour_on_corner_wrapping([Negative, Positive, Negative]).coords(), [0, 3, 2]);
+    /// assert_eq!(location.neighbour_on_corner_wrapping([Negative, Negative, Positive]).coords(), [0, 1, 4]);
+    ///
+    /// let edge_location = Morton::<Expand<u16, 2>, 2>::from_coords([0, u16::MAX]);
+    /// assert_eq!(edge_location.neighbour_on_corner_wrapping([Negative, Negative]).coords(), [u16::MAX, u16::MAX - 1]);
+    /// assert_eq!(edge_location.neighbour_on_corner_wrapping([Positive, Positive]).coords(), [1, 0]);
+    /// ```
     fn neighbour_on_corner_wrapping(&self, axes: [QueryDirection; D]) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,11 +111,11 @@ impl CurveIndex for usize {}
 /// Direction to search within an axis when making queries
 #[derive(Clone, Copy, Debug)]
 pub enum QueryDirection {
-    /// Search in a positive direction along an axis relative to the source location
-    Positive,
-
     /// Search in a negative direction along an axis relative to the source location
     Negative,
+
+    /// Search in a positive direction along an axis relative to the source location
+    Positive,
 }
 
 impl QueryDirection {
@@ -427,4 +427,7 @@ pub trait Neighbours<const D: usize>: SpaceFillingCurve<D> {
     /// assert_eq!(edge_location.neighbour_on_axis_wrapping(1, QueryDirection::Positive).coords(), [0, 0]);
     /// ```
     fn neighbour_on_axis_wrapping(&self, axis: usize, direction: QueryDirection) -> Self;
+
+    fn neighbour_on_corner(&self, axes: [QueryDirection; D]) -> Option<Self>;
+    fn neighbour_on_corner_wrapping(&self, axes: [QueryDirection; D]) -> Self;
 }


### PR DESCRIPTION
Adding first pass neighbour_on_corner methods on the Neighbours trait. Combined with neighbour_on_axis, these methods enable complete iteration of all surrounding neighbours (though iterators have not yet been implemented).

I'm not convinced these are implemented in an optimal manner, but they serve as a first stab at the functionality.

I suspect there may be a simpler bit twiddling method.